### PR TITLE
docs: add architecture overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@
 - `tests/` – executable scripts.
 
 ## Critical Docs
+- `docs/ARCHITECTURE.md` – project structure overview.
 - `configs/CLAUDE.md` – config fields & commands.
 - `tests/CLAUDE.md` – test catalog & usage.
 - `examples/CLAUDE.md` – library patterns.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ BHDS is primarily intended for cryptocurrency quantitative trading research usin
 
 This project is released under the **MIT License**.
 
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for an overview of the project layout.
+
 **Be careful, I'm refactoring this project, the code may be broken.**
 
 ## Environment

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,29 @@
+# Architecture
+
+This document summarizes the main modules and data layout used by **BHDS**.
+
+## Directory Structure
+```
+├── legacy/                     # Legacy code (deprecated, moved from scripts/)
+├── src/                        # Modern refactored structure
+│   ├── bhds/                   # New modular CLI and task implementations
+│   │   ├── cli.py              # CLI entry point (`uv run bhds`)
+│   │   ├── aws/                # AWS client and download helpers
+│   │   ├── holo_kline/         # Holographic 1‑minute kline synthesis
+│   │   └── tasks/              # Task implementations
+│   └── bdt_common/             # Shared utilities (logging, network, Polars helpers)
+├── configs/                    # YAML task configurations
+├── examples/                   # Library usage examples
+├── scripts/                    # Minimal shell scripts (backup only)
+├── tests/                      # Test files and executable scripts
+└── notebook/                   # Jupyter analysis notebooks
+```
+
+## Storage Structure
+```
+$CRYPTO_BASE_DIR/binance_data/
+├── aws_data/           # Raw AWS downloads (.zip)
+├── parsed_data/        # Processed AWS data (.parquet)
+├── results_data/       # Final datasets
+│   └── holo_1m_klines/ # Holographic 1‑minute klines (with VWAP & funding)
+```


### PR DESCRIPTION
## Summary
- document project layout in new `docs/ARCHITECTURE.md`
- reference architecture doc from root `CLAUDE.md` and `README.md`

## Testing
- `uv run tests/aws_client.py` *(fails: aiohttp.client_exceptions.ClientHttpProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a04864b4648321a10dd60a84b36ec6