### PR TITLE
Clarify funding fallback log message

### DIFF
--- a/src/bhds/holo_kline/merger.py
+++ b/src/bhds/holo_kline/merger.py
@@ -98,8 +98,8 @@ class Holo1mKlineMerger:
                     funding_ldf.select(["candle_begin_time", "funding_rate"]), on="candle_begin_time", how="left"
                 ).with_columns(pl.col("funding_rate").fill_null(0))
             else:
-                logger.warning(f"Funding directory not found for {symbol}: {funding_dir}")
-                self.include_funding = False
+                logger.warning(f"Funding data not found for {symbol}, filling funding_rate with 0: {funding_dir}")
+                ldf = ldf.with_columns(pl.lit(0).alias("funding_rate"))
 
         # Fill kline gaps (ensure time continuity)
         ldf = self._fill_kline_gaps(ldf)


### PR DESCRIPTION
### Motivation
- Make it explicit in logs when funding data is missing and that a fallback of zeros is being applied to the funding column to avoid confusion about funding handling.

### Description
- Update the `logger.warning` text to state that funding data is missing and that `funding_rate` will be filled with `0` for the given symbol.
- Ensure the code populates a `funding_rate` column with zeros by adding `ldf = ldf.with_columns(pl.lit(0).alias("funding_rate"))` when the funding directory is not present and `self.include_funding` is not toggled.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cd25ab9748321b9a9f9a30574e984)